### PR TITLE
Chore: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ analysis_benchmark.json
 .pub-preload-cache/
 .pub/
 build/
+devtools_options.yaml
 flutter_*.png
 linked_*.ds
 unlinked.ds
@@ -121,3 +122,21 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# Rider
+.idea/
+.idea/caches/
+.idea/modules.xml
+.idea/runConfigurations/
+.idea/workspace.xml
+
+# Flutter
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Dart
+.dart_tool/


### PR DESCRIPTION
Adds devtools_options.yaml to .gitignore and cleans up duplicate entries.